### PR TITLE
Issue 12 - P2P test page leads to dead link

### DIFF
--- a/src/peer2peer/js/main.js
+++ b/src/peer2peer/js/main.js
@@ -391,7 +391,7 @@ function displayScreenCaptureInfo() {
                 '2. Check: "Enable Developer mode"<br>' +
                 '3. Click: "Load the unpacked extension..."<br>' +
                 '4. Choose "extension" folder from the ' +
-                '<a href="http://goo.gl/kLEycY">repository</a><br>' +
+                '<a href="https://goo.gl/Q9y2R8">repository</a><br>' +
                 '5. Reload this page over https<br>' +
                 'Note: Make sure the URL permission in manifest.json matches ' +
                 'the URL for this page.';


### PR DESCRIPTION
Added the correct link for the extension in the peer2peer test page

Correct Link
https://github.com/webrtc/test-pages/tree/gh-pages/src/peer2peer/extension
Or 
https://github.com/webrtc/test-pages/blob/gh-pages/src/peer2peer/extension/screencapture.zip

Dead Link
https://github.com/webrtc/testrtc/tree/master/src/manual/peer2peer/extension

Added the Link as goo.gl URL. 