### PR TITLE
Fixing Menifest file - Github Issue #17 (test-pages)

### DIFF
--- a/src/peer2peer/extension/src/manifest.json
+++ b/src/peer2peer/extension/src/manifest.json
@@ -11,12 +11,12 @@
   },
   "content_scripts": [
     {
-      "matches": ["https://test.webrtc.org/manual/*"],
+      "matches": ["https://webrtc.github.io/test-pages/src/peer2peer/*"],
       "js": ["content-script.js"]
     }
   ],
   "permissions": [
     "desktopCapture",
-    "https://test.webrtc.org/manual/*"
+    "https://webrtc.github.io/test-pages/src/peer2peer/*"
   ]
 }


### PR DESCRIPTION
Problem: 
Desktop screensharing test page is not working. the menifest file has the wrong link, once you load the extension from the chrome://extensions - load extension feature, Its not working. 

Added correct link for the screencapture to function.
Correct Link: https://webrtc.github.io/test-pages/src/peer2peer/*