### PR TITLE
Fix deprecated iframe tag in M64 issue 458

### DIFF
--- a/src/iframe-apprtc/index.html
+++ b/src/iframe-apprtc/index.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <!--
-  Copyright (c) 2015 The WebRTC project authors. All Rights Reserved.
+  Copyright (c) 2017 The WebRTC project authors. All Rights Reserved.
 
   Use of this source code is governed by a BSD-style license
   that can be found in the LICENSE file in the root of the source
@@ -14,7 +14,11 @@
   <meta http-equiv="X-UA-Compatible" content="chrome=1"/>
 </head>
 <body>
-  AppRTC in an &lt;iframe&gt; element:<br>
-  <iframe width="90%" height="1200px" src="//appr.tc"></iframe>
+  AppRTC in an &lt;iframe&gt; element: To be deprecated in M64 (~ Jan 2018) <br>
+  <iframe width="50%" height="600px" src="//appr.tc"></iframe>
+  <hr>
+  To test website still uses cross-origin iframes
+  <iframe width="50%" height="600px" src="//appr.tc" allow="geolocation; microphone; camera"></iframe>
+  <hr>
 </body>
 </html>


### PR DESCRIPTION
Description:

iFrame current Implementation about to be Deprecated in Jan 2018 and we want developers to use iframes (if they still use cross-origin iframes) in the new way - refer : https://goo.gl/jiUTvW 

Changes:

Added the new way of handling iFrames based on https://goo.gl/jiUTvW in a second sample (by keeping the old sample on top). 